### PR TITLE
override type if already exists

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -235,7 +235,11 @@ class DoctrineServiceProvider extends ServiceProvider
         // @see http://doctrine-mongodb-odm.readthedocs.org/en/latest/reference/basic-mapping.html#custom-mapping-types
         if (isset($doctrineConfig['types'])) {
             foreach ($doctrineConfig['types'] as $name => $className) {
-                Type::addType($name, $className);
+                if ( ! Type::hasType($name)) {
+                    Type::addType($name, $className);
+                } else {
+                    Type::overrideType($name, $className);
+                }
             }
         }
     }


### PR DESCRIPTION
Lumen tests try to register DoctrineServiceProvider more than once and when it happens, Type throws `MappingException('Type short_id already exists.')` (which I believe to be the first type to be registered). This also gives the possibility to override default types.
